### PR TITLE
key error on managednode in _GET_APP_GQL

### DIFF
--- a/echostream_node/__init__.py
+++ b/echostream_node/__init__.py
@@ -70,6 +70,7 @@ _GET_APP_GQL = gql(
             }
             ... on ManagedNode {
                 app {
+                    __typename
                     name
                     tableAccess
                 }


### PR DESCRIPTION
env/lib/python3.9/site-packages/echostream_node/__init__.py", line 359, in __init__
    self.__app_type = data["app"]["__typename"]
KeyError: '__typename'